### PR TITLE
Disable curl silent mode, enable insecure connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(OSX_DRV):
 	@echo ""
 	@# Ty to wvengen, see: https://github.com/patjak/bcwc_pcie/issues/14#issuecomment-167446787
 	@echo "Downloading the driver, please wait..."
-	@(curl -s -L -r "$(RANGE)" "$(URL)" | xzcat -q | cpio --format odc -i -d "./$(FILE)") &> /dev/null || true
+	@(curl -k -L -r "$(RANGE)" "$(URL)" | xzcat -q | cpio --format odc -i -d "./$(FILE)") &> /dev/null || true
 	@mv "$(FILE)" .
 	@rmdir -p "$(OSX_DRV_DIR)"
 


### PR DESCRIPTION
Fix curl silently failing (outdated certs).

Support insecure connections, so firmware is downloaded anyway.